### PR TITLE
automatic model training

### DIFF
--- a/backend/licenses/management/commands/check_licenses_expired.py
+++ b/backend/licenses/management/commands/check_licenses_expired.py
@@ -5,7 +5,7 @@ from messaging.services.messenger import MessengerService
 from licenses.models import License, Status
 import logging
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('check_licenses_expired')
 
 class Command(BaseCommand):
     help = 'Actualiza licencias vencidas'
@@ -34,7 +34,7 @@ class Command(BaseCommand):
                 if expired_time == today:
                     MessengerService.send_last_day_to_upload_certificate_message(license)
                     logger.info(f"Se notifico al usuario que solicito la licencia {license.license_id} que el ultimo dia para cargar el certificado es hoy")
-                    licenses_expiring_today=+1
+                    licenses_expiring_today+=1
 
                 if expired_time < today:
                     license.status.name = Status.StatusChoices.EXPIRED

--- a/backend/ml_models/management/commands/automatic_model_training.py
+++ b/backend/ml_models/management/commands/automatic_model_training.py
@@ -1,0 +1,44 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from ml_models.utils.coherence_model_ml import train_and_save_coherence_model
+from ml_models.utils.evaluation_model import train_and_save_approval_model, train_and_save_rejection_reason_model
+import logging
+
+# Configuración mejorada del logger
+logger = logging.getLogger('automatic_models_training')
+
+class Command(BaseCommand):
+    help = 'Entrenamiento automático de modelos de ML'
+    
+    def handle(self, *args, **options):
+        # Inicio del proceso
+        start_time = timezone.now()
+        logger.info(f"\n{'='*50}\nIniciando entrenamiento de modelos - {start_time.strftime('%Y-%m-%d %H:%M:%S')}\n{'='*50}")
+        
+        try:
+            logger.info("Entrenando modelo de coherencia...")
+            train_and_save_coherence_model()
+            logger.info("Modelo de coherencia entrenado exitosamente")
+            
+            logger.info("Entrenando modelo de aprobación...")
+            train_and_save_approval_model()
+            logger.info("Modelo de aprobación entrenado exitosamente")
+            
+            logger.info("Entrenando modelo de razón de rechazo...")
+            train_and_save_rejection_reason_model()
+            logger.info("Modelo de razón de rechazo entrenado exitosamente")
+            
+            # Reporte final
+            duration = timezone.now() - start_time
+            logger.info(f"\n{'='*50}\nEntrenamiento completado exitosamente\n"
+                      f"Duración total: {duration}\n"
+                      f"Fecha finalización: {timezone.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                      f"{'='*50}")
+            
+        except Exception as e:
+            duration = timezone.now() - start_time
+            logger.error(f"\n{'='*50}\nError durante el entrenamiento de modelos\n"
+                        f"Error: {str(e)}\n"
+                        f"Duración hasta error: {duration}\n"
+                        f"Fecha error: {timezone.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                        f"{'='*50}")

--- a/backend/ml_models/utils/coherence_model_ml.py
+++ b/backend/ml_models/utils/coherence_model_ml.py
@@ -12,6 +12,7 @@ from .spanish_stopwords import SPANISH_STOPWORDS
 from ml_models.models import MLModel
 from datetime import datetime
 from ml_models.models import LicenseDatasetEntry
+from django.utils import timezone
 # Paths
 MODEL_PATH = Path(__file__).resolve().parent / 'modelo_clasificador.joblib'
 DATASET_PATH = Path(__file__).resolve().parent / 'coherence_license_type_dataset.csv'
@@ -76,7 +77,7 @@ def train_and_save_coherence_model():
         name= 'Modelo de coherencia de certificados',
         algorithm= 'RANDOM_FOREST',
         is_active= True,
-        training_date = datetime.now(),
+        training_date = timezone.now(),
         first_training_id= first_id,
         last_training_id= last_id
         )

--- a/backend/ml_models/utils/evaluation_model.py
+++ b/backend/ml_models/utils/evaluation_model.py
@@ -12,7 +12,7 @@ from ml_models.models import MLModel
 from ml_models.utils.file_utils import normalize_text
 from .spanish_stopwords import SPANISH_STOPWORDS
 from sklearn.model_selection import cross_val_score, StratifiedKFold
-from datetime import datetime
+from django.utils import timezone
 from ml_models.models import LicenseDatasetEntry
 
 
@@ -349,7 +349,7 @@ def train_and_save_approval_model():
         name='Modelo de aprobación de licencias',
         algorithm='LGBM',
         is_active=True,
-        training_date=datetime.now(),
+        training_date = timezone.now(),
         first_training_id=first_id,
         last_training_id=last_id
     )
@@ -431,7 +431,7 @@ def train_and_save_rejection_reason_model():
         name='Modelo de clasificacion de motivos de rechazo',
         algorithm='LGBM',
         is_active=True,
-        training_date=datetime.now(),
+        training_date = timezone.now(),
         first_training_id=first_id,
         last_training_id=last_id
     )

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -184,10 +184,21 @@ LOGGING = {
             'filename': os.path.join(BASE_DIR, 'logs', 'licenses.log'),
             'formatter': 'verbose',
         },
+        'training_file': {  
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'logs', 'models_training.log'),
+            'formatter': 'verbose',
+        },
     },
     'loggers': {
-        'licenses.management.commands.check_licenses_expired': {
+        'check_licenses_expired': {
             'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'automatic_models_training': {  
+            'handlers': ['console', 'training_file'],  
             'level': 'INFO',
             'propagate': False,
         },


### PR DESCRIPTION
## 📌 Descripción

<!-- Explicá brevemente qué cambios implementa este PR y por qué son necesarios -->
- ¿Qué se resolvió?
- ¿Qué se agregó o eliminó?
Se crea tarea automática para reentremaniento de modelos.

---

## 🛠 Cambios realizados
- [x ] Nuevo feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentación
- [ ] Otros: ____________________

---

## 🔍 ¿Cómo probarlo?

<!-- Instrucciones para testear este PR -->
En ubuntu 
1.  En la terminal ejecutar el comando : crontab -e
2.  En la ultima linea pegar lo siguiente:
00 13 * * * /home/fabihunt/virtualenvs/health_first/bin/python /home/fabihunt/ungs/labo/TP-Principal-Labo/HealthFirst/backend/manage.py automatic_model_training

(reemplazar la hora por la que se quiera correr la tarea)
IMPORTANTE : Remplazar la primera ruta por la de su entorno virtual y la segunda por la ruta del manage.py en su pc.

En windows configurar la tarea con el administrador de tareas.

Una vez que se ejecute en la carpeta logs en el archivo models_traning veran si se ejecuto correctamente.
4. 

## 🧪 cURL (para testear endpoints)

```bash
# Describí brevemente qué hace esta petición
curl -X GET "http://localhost:8080/api/" -H "Authorization: Bearer <TOKEN>"


---

## ✅ Checklist
- [ ] Se aplican migraciones
- [ ] Todos los tests pasan correctamente
- [ ] No hay warnings o errores en consola
- [ ] Se actualizó la documentación (si aplica)
---

## 🧩 Issues relacionados

<!-- Si este PR cierra o se relaciona con una tarjeta -->


---

## 💬 Notas adicionales

<!-- Cualquier detalle adicional, limitación o algo que el revisor deba saber -->
